### PR TITLE
Little Renames from Functions to Static Functions to keep the Format generalized

### DIFF
--- a/docs/scripting-reference/utility-classes/json.mdx
+++ b/docs/scripting-reference/utility-classes/json.mdx
@@ -35,7 +35,7 @@ Note that custom classes \(e.g. **Vehicle**, **Vector**, **Character**… etc\) 
 
 :::
 
-### Functions
+### Static Functions
 
 | **Returns** | **Name** | **Description** |
 | :--- | :--- | :--- |

--- a/docs/scripting-reference/utility-classes/nanosmath.mdx
+++ b/docs/scripting-reference/utility-classes/nanosmath.mdx
@@ -21,7 +21,7 @@ import { BasicType, Structs } from '@site/docs/components/_nanos.mdx';
 local axis = NanosMath.ClampAxis(720)
 ```
 
-## Functions
+## Static Functions
 
 | Returns | Name | Description |
 | :--- | :--- | :--- |

--- a/docs/scripting-reference/utility-classes/nanosutils.mdx
+++ b/docs/scripting-reference/utility-classes/nanosutils.mdx
@@ -43,7 +43,7 @@ NanosUtils.IsA(my_variable, Character) -- true
 NanosUtils.IsA(my_variable, Vehicle) -- false
 ```
 
-## Functions
+## Static Functions
 
 | Returns | Name | Description |
 | :--- | :--- | :--- |


### PR DESCRIPTION
Three of the Utility Classes Docs have Static Functions which are declared as normal Functions. To keep the Format the same over the whole Docs I've changed the lines :)