### PR TITLE
func 'Character' called with only Vector make error

### DIFF
--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -148,7 +148,7 @@ Let's append some code in your `Index.lua`, to spawn a <Classes.Character /> whe
 -- Function to spawn a Character to a player
 function SpawnCharacter(player)
     -- Spawns a Character at position 0, 0, 0 with default's constructor parameters
-    local new_character = Character(Vector(0, 0, 0))
+    local new_character = Character(Vector(0, 0, 0), Rotator(0, 0, 0), "nanos-world::SK_Male")
 
     -- Possess the new Character
     player:Possess(new_character)


### PR DESCRIPTION
[2022-10-05 14:58:13] [error]    Lua Error on Class 'Player' Event: 'Spawn':
        - [0] [base-player/Server/Index.lua]:7: Error on spawning entity 'Character': None of the constructors matched the passed arguments. Got: (Vector). Tried:
                Character(Vector, Rotator, string?, enum?, boolean?, number?, string?, string?)

        - [1] [base-player/Server/Index.lua]:7: in function <[string "base-player/Server/Index.lua"]:5>