### PR TITLE
Update instructions for server game panels

### DIFF
--- a/docs/core-concepts/server-manual/game-panels.md
+++ b/docs/core-concepts/server-manual/game-panels.md
@@ -22,6 +22,8 @@ Sources and installation files are open source at Falaxir GitHub: https://github
 
 Configuration and installation of this panel can be quite complex, we recommand you read the instructions fully before proceeding.
 
+More information can be read at [their website](https://pterodactyl.io/)
+
 ### Requirements
 
 - Latest linux OS
@@ -67,7 +69,7 @@ You can change avoid that by removing the parameter on the startup command insid
 
 ## AMP Installation
 
-Installation and use of this panel is one of the easiest. 
+Information about this panel can be read at [the cubecoders website](https://cubecoders.com/AMP)
 
 ### Requirements
 

--- a/docs/core-concepts/server-manual/game-panels.md
+++ b/docs/core-concepts/server-manual/game-panels.md
@@ -14,72 +14,107 @@ The use of Game Panels is not officially supported and currently maintained by t
 
 :::
 
-Currently nanos world is supported on 2 games panel: https://pterodactyl.io and https://cubecoders.com/AMP.
+Currently nanos world is supported on 2 games panel: [Pterodactyl Panel](https://pterodactyl.io) and [AMP (Application Management Panel)](https://cubecoders.com/AMP).
 
-Installation files are open source at Falaxir GitHub: https://github.com/Falaxir/nanos-world_yolks-game-panels. You can also check which features are supported.
+Sources and installation files are open source at Falaxir GitHub: https://github.com/Falaxir/nanos-world_yolks-game-panels. You can also check which features are supported.
 
 ## Pterodactyl Installation
 
-The installation of this panel can be complex depending on the type of your infrastructure. This panel is only compatible on Linux and the server must have a docker compatible system (OpenVZ is not compatible).
+Configuration and installation of this panel can be quite complex, we recommand you read the instructions fully before proceeding.
 
-If you haven't installed the panel yet, we recommend using the unofficial installer available here: https://github.com/vilhelmprytz/pterodactyl-installer.
+### Requirements
 
-### Installing the `egg`
+- Latest linux OS
+    - Ubuntu, Debian, others os may require extra work
+- Dedicated server (no virtualisation) or Virtual machine (including VPS) using KVM virtualisation (OpenVZ is incompatible)
+    - You can check with the linux command `hostnamectl`, it will be written under "Virtualization"
 
-Once the panel is installed, download the file `egg-nanos-world-server.json` located inside the `pterodactyl-egg` folder on GitHub.
+If you haven't installed the panel yet, we recommend using the unofficial [pterodactyl-installer available on github](https://github.com/vilhelmprytz/pterodactyl-installer).
 
-Then, go to your panel on the category `SERVICE MANAGEMENT` and click on `NESTS`.
+### Installing the game server
 
-You can create a new `NEST` by clicking the create button or selecting an existing nest.
+Custom unofficial game servers can be installed in Pterodactyl panel as an `"egg"` with a `.json` file
 
-After the nest is created, go back to the `NESTS` and click on the button `Import EGG`, select the .json file you downloaded earlier and on the dropdown menu, select the nest you created earlier.
+The list of eggs can be found on the [installation github under the folder pterodactyl-egg](https://github.com/Falaxir/nanos-world_yolks-game-panels/tree/master/pterodactyl-egg). You can choose and download between two versions :
+- egg-nanos-world-server.json
+    - Stable branch of nanos world server
+- egg-nanos-world-server-BLEEDING-EDGE.json
+    - Bleeding edge branch for latest features before they are stable
+
+To install theses files, go to your panel `Admin` page then click on the `NESTS` button (under the category `SERVICE MANAGEMENT`).
+
+Create a new `NEST` by clicking the `Create New` button and give it any name you want.
+
+After the nest is created, go back to the `NESTS` page and click on the button `Import EGG`, select the .json file you downloaded earlier and on the dropdown menu, select the nest you created earlier.
 
 :::tip
 
-Finished! You can now create a nanos world server as usual inside the panel!
+Congrats! You have installed nanos world server on pterodactyl!. You can check how to configure the server below.
 
 :::
 
+### Configuring nanos server
+
+Most configuration can be edited on the main nanos world config file `Config.toml` available on the `Files` category on the panel
+
+:::caution
+
+Parameters such as Query Port, Announce, Max Players, Map => can only be edited in the `Startup` category on the panel. If these values are changed on config file, they will be overwritten !
+
+You can change avoid that by removing the parameter on the startup command inside pterodactyl egg.
+
+:::
 
 ## AMP Installation
 
-The installation of this panel is the easiest, you can go to https://cubecoders.com/AMPInstall and follow the instruction to install the panel.
+Installation and use of this panel is one of the easiest. 
 
-It works even with OpenVZ virtualization and windows!
+### Requirements
+
+- Latest linux os or windows os
+    - Ubuntu, Debian, Windows 10 & 11, others os may require extra work. Full list on the AMP installation page.
+- Dedicated server (no virtualisation) or Virtual machine (including VPS) using KVM or OpenVZ virtualisation
+
+The installation of this panel is the easiest, you can go to the [installation page](https://cubecoders.com/AMPInstall) and follow the instruction to install the panel.
 
 :::info Note
 
-This panel requires a license that can be bought at https://cubecoders.com/AMP. Your main ADS instance (ADS01) can have a different name.
+This panel requires a license that can be bought at https://cubecoders.com/AMP.
 
 :::
 
 ### Installing the template
 
-Once the panel is installed, shutdown the ADS instance, you can do it on Linux by typing this command:
-```bash
-ampinstmgr -q ADS01
-```
+Custom unofficial game servers can be installed by adding a github template repository on AMP.
 
-:::info Note
+Go to your Main menu panel, then go to : `Configuration` -> `Instance Deployment` And then on the category `Instance Management`
 
-To run `ampinstmgr` commands, you need to run them as the user `amp`, you can switch to this user using the command: `sudo su -l amp`.
+On the `Configuration Repositories`, click on the `+` icon and add the following value : `Falaxir/AMPTemplates`
 
-:::
+Finally, click `Fetch Latest` and now when you go back to your Main menu and create a new instance, you should have the application Nanos world that is under the name of `Falaxir / Nanos World`
 
-After, go to your server files inside the folder
-```text
-/home/amp/.ampdata/instances/ADS01/Plugins/ADSModule/DeploymentTemplates/CubeCoders-AMPTemplates
-```
-
-Then download the files on GitHub inside the folder `amp-generic` (.kvp & .json) and put them on your server.
-
-You can start the panel again by typing:
-```bash
-ampinstmgr -s ADS01
-```
+You will be able to choose two versions :
+- `Falaxir / Nanos World`
+    - Stable branch of nanos world server
+- `Falaxir / Nanos World - Bleeding edge`
+    - Bleeding edge branch for latest features before they are stable
 
 :::tip
 
-Finished! You can now create a nanos world server as usual inside the panel!
+Congrats! You have installed nanos world server on pterodactyl!. You can check how to configure the server below.
 
 :::
+
+### Configuring nanos server
+
+Most configuration can be edited on the main nanos world config file `Config.toml` available on the `Files` category on the panel
+
+:::caution
+
+Parameters such as Server name & description, Map => can only be edited in the `Nanos World` category on the panel. If these values are changed on config file, they will be overwritten !
+
+Ports (game & query) and player slots are managed by AMP and can be edited. 
+
+:::
+
+Please follow the official [documentation of AMP](https://discourse.cubecoders.com/docs/) for more info about managing an instance.

--- a/versioned_docs/version-latest/core-concepts/server-manual/game-panels.md
+++ b/versioned_docs/version-latest/core-concepts/server-manual/game-panels.md
@@ -22,6 +22,8 @@ Sources and installation files are open source at Falaxir GitHub: https://github
 
 Configuration and installation of this panel can be quite complex, we recommand you read the instructions fully before proceeding.
 
+More information can be read at [their website](https://pterodactyl.io/)
+
 ### Requirements
 
 - Latest linux OS
@@ -67,7 +69,7 @@ You can change avoid that by removing the parameter on the startup command insid
 
 ## AMP Installation
 
-Installation and use of this panel is one of the easiest. 
+Information about this panel can be read at [the cubecoders website](https://cubecoders.com/AMP)
 
 ### Requirements
 

--- a/versioned_docs/version-latest/core-concepts/server-manual/game-panels.md
+++ b/versioned_docs/version-latest/core-concepts/server-manual/game-panels.md
@@ -14,72 +14,107 @@ The use of Game Panels is not officially supported and currently maintained by t
 
 :::
 
-Currently nanos world is supported on 2 games panel: https://pterodactyl.io and https://cubecoders.com/AMP.
+Currently nanos world is supported on 2 games panel: [Pterodactyl Panel](https://pterodactyl.io) and [AMP (Application Management Panel)](https://cubecoders.com/AMP).
 
-Installation files are open source at Falaxir GitHub: https://github.com/Falaxir/nanos-world_yolks-game-panels. You can also check which features are supported.
+Sources and installation files are open source at Falaxir GitHub: https://github.com/Falaxir/nanos-world_yolks-game-panels. You can also check which features are supported.
 
 ## Pterodactyl Installation
 
-The installation of this panel can be complex depending on the type of your infrastructure. This panel is only compatible on Linux and the server must have a docker compatible system (OpenVZ is not compatible).
+Configuration and installation of this panel can be quite complex, we recommand you read the instructions fully before proceeding.
 
-If you haven't installed the panel yet, we recommend using the unofficial installer available here: https://github.com/vilhelmprytz/pterodactyl-installer.
+### Requirements
 
-### Installing the `egg`
+- Latest linux OS
+    - Ubuntu, Debian, others os may require extra work
+- Dedicated server (no virtualisation) or Virtual machine (including VPS) using KVM virtualisation (OpenVZ is incompatible)
+    - You can check with the linux command `hostnamectl`, it will be written under "Virtualization"
 
-Once the panel is installed, download the file `egg-nanos-world-server.json` located inside the `pterodactyl-egg` folder on GitHub.
+If you haven't installed the panel yet, we recommend using the unofficial [pterodactyl-installer available on github](https://github.com/vilhelmprytz/pterodactyl-installer).
 
-Then, go to your panel on the category `SERVICE MANAGEMENT` and click on `NESTS`.
+### Installing the game server
 
-You can create a new `NEST` by clicking the create button or selecting an existing nest.
+Custom unofficial game servers can be installed in Pterodactyl panel as an `"egg"` with a `.json` file
 
-After the nest is created, go back to the `NESTS` and click on the button `Import EGG`, select the .json file you downloaded earlier and on the dropdown menu, select the nest you created earlier.
+The list of eggs can be found on the [installation github under the folder pterodactyl-egg](https://github.com/Falaxir/nanos-world_yolks-game-panels/tree/master/pterodactyl-egg). You can choose and download between two versions :
+- egg-nanos-world-server.json
+    - Stable branch of nanos world server
+- egg-nanos-world-server-BLEEDING-EDGE.json
+    - Bleeding edge branch for latest features before they are stable
+
+To install theses files, go to your panel `Admin` page then click on the `NESTS` button (under the category `SERVICE MANAGEMENT`).
+
+Create a new `NEST` by clicking the `Create New` button and give it any name you want.
+
+After the nest is created, go back to the `NESTS` page and click on the button `Import EGG`, select the .json file you downloaded earlier and on the dropdown menu, select the nest you created earlier.
 
 :::tip
 
-Finished! You can now create a nanos world server as usual inside the panel!
+Congrats! You have installed nanos world server on pterodactyl!. You can check how to configure the server below.
 
 :::
 
+### Configuring nanos server
+
+Most configuration can be edited on the main nanos world config file `Config.toml` available on the `Files` category on the panel
+
+:::caution
+
+Parameters such as Query Port, Announce, Max Players, Map => can only be edited in the `Startup` category on the panel. If these values are changed on config file, they will be overwritten !
+
+You can change avoid that by removing the parameter on the startup command inside pterodactyl egg.
+
+:::
 
 ## AMP Installation
 
-The installation of this panel is the easiest, you can go to https://cubecoders.com/AMPInstall and follow the instruction to install the panel.
+Installation and use of this panel is one of the easiest. 
 
-It works even with OpenVZ virtualization and windows!
+### Requirements
+
+- Latest linux os or windows os
+    - Ubuntu, Debian, Windows 10 & 11, others os may require extra work. Full list on the AMP installation page.
+- Dedicated server (no virtualisation) or Virtual machine (including VPS) using KVM or OpenVZ virtualisation
+
+The installation of this panel is the easiest, you can go to the [installation page](https://cubecoders.com/AMPInstall) and follow the instruction to install the panel.
 
 :::info Note
 
-This panel requires a license that can be bought at https://cubecoders.com/AMP. Your main ADS instance (ADS01) can have a different name.
+This panel requires a license that can be bought at https://cubecoders.com/AMP.
 
 :::
 
 ### Installing the template
 
-Once the panel is installed, shutdown the ADS instance, you can do it on Linux by typing this command:
-```bash
-ampinstmgr -q ADS01
-```
+Custom unofficial game servers can be installed by adding a github template repository on AMP.
 
-:::info Note
+Go to your Main menu panel, then go to : `Configuration` -> `Instance Deployment` And then on the category `Instance Management`
 
-To run `ampinstmgr` commands, you need to run them as the user `amp`, you can switch to this user using the command: `sudo su -l amp`.
+On the `Configuration Repositories`, click on the `+` icon and add the following value : `Falaxir/AMPTemplates`
 
-:::
+Finally, click `Fetch Latest` and now when you go back to your Main menu and create a new instance, you should have the application Nanos world that is under the name of `Falaxir / Nanos World`
 
-After, go to your server files inside the folder
-```text
-/home/amp/.ampdata/instances/ADS01/Plugins/ADSModule/DeploymentTemplates/CubeCoders-AMPTemplates
-```
-
-Then download the files on GitHub inside the folder `amp-generic` (.kvp & .json) and put them on your server.
-
-You can start the panel again by typing:
-```bash
-ampinstmgr -s ADS01
-```
+You will be able to choose two versions :
+- `Falaxir / Nanos World`
+    - Stable branch of nanos world server
+- `Falaxir / Nanos World - Bleeding edge`
+    - Bleeding edge branch for latest features before they are stable
 
 :::tip
 
-Finished! You can now create a nanos world server as usual inside the panel!
+Congrats! You have installed nanos world server on pterodactyl!. You can check how to configure the server below.
 
 :::
+
+### Configuring nanos server
+
+Most configuration can be edited on the main nanos world config file `Config.toml` available on the `Files` category on the panel
+
+:::caution
+
+Parameters such as Server name & description, Map => can only be edited in the `Nanos World` category on the panel. If these values are changed on config file, they will be overwritten !
+
+Ports (game & query) and player slots are managed by AMP and can be edited. 
+
+:::
+
+Please follow the official [documentation of AMP](https://discourse.cubecoders.com/docs/) for more info about managing an instance.


### PR DESCRIPTION
This PR updates the instructions of installing nanos world server inside game panels such as AMP and pterodactyl.

it mostly do the following :
- Update outdated instructions for AMP that are not working anymore
- Update docker image to latest debian os version for pterodactyl images
- Add base and bleeding-edge nanos server images for both AMP and pterodactyl
- Add warning about potential issues for editing configuration files
- more that i forgot :)