### PR TITLE
Correct note punctuation in ADK documentation

### DIFF
--- a/docs/assets-modding/creating-assets/adk-assets-development-kit.md
+++ b/docs/assets-modding/creating-assets/adk-assets-development-kit.md
@@ -91,7 +91,7 @@ This is a pre-configured **Sun & Sky Blueprint** which can be used and easily re
 
 :::info
 
-**Note:** Overriding the Sun through Scripting with `World.SpawnDefaultSun()`, will respawn the Sun actor, which means no configuration did on the Sun & Sky actor will persist
+**Note:** Overriding the Sun through Scripting with `World.SpawnDefaultSun()`, will respawn the Sun actor, which means no configuration did on the Sun & Sky actor will persist.
 
 Example: Light Intensity, Color, Post Process and other configuration will be lost.
 


### PR DESCRIPTION
Fixed punctuation in note about overriding the Sun actor.